### PR TITLE
Reviewed text and descriptions

### DIFF
--- a/advanced.ipynb
+++ b/advanced.ipynb
@@ -31,7 +31,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "df = pd.read_csv('./data/all_data.csv')\n",
@@ -48,7 +50,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "import pickle\n",
@@ -87,7 +91,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "predicted_labels = classifier.predict(df['text'])\n",
@@ -104,7 +110,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "(df.groupby('source')['label'].sum() / df.groupby('source').size()).plot('barh')"
@@ -114,13 +122,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The Finanicial times is surprisingly high. Let's inspect."
+    "The Financial Times is surprisingly high. Let's inspect."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "df.groupby('source').get_group('financial-times')"

--- a/tutorial.ipynb
+++ b/tutorial.ipynb
@@ -53,9 +53,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "df = pd.read_csv('./data/training_data.csv')\n",
@@ -81,9 +79,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print(df['title'][1])\n",
@@ -98,15 +94,13 @@
    "source": [
     "### Basic statistics\n",
     "\n",
-    "Pandas makes it's easy to inspect, plot, and transform our data. Pandas is easy to use but still has lot's of functionality. When you can chain multiple functions together, you've become a pandas pro!"
+    "Pandas makes it easy to inspect, plot, and transform our data. Pandas is easy to use but still has lots of functionality. When you can chain multiple functions together, you've become a pandas pro!"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Number of clickbait and non-clickbait articles\n",
@@ -116,9 +110,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Plotting the number of author fields that are Null\n",
@@ -128,9 +120,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# The number of characters in the description field\n",
@@ -140,9 +130,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Comparing the number of description characters in clickbait to news\n",
@@ -172,9 +160,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "df['full_content'] = (df.description + df.title)\n",
@@ -198,7 +184,7 @@
    "source": [
     "---\n",
     "\n",
-    "# Text classification pipeline\n",
+    "# Scikit-learn text classification pipeline\n",
     "\n",
     "\n",
     "Some important terminology:\n",
@@ -234,7 +220,9 @@
     "\n",
     "This is simply achieved with a scikit-learn `CountVectorizer`. There are two steps:\n",
     " - **Fit** the vectorizer, which populates all the tokens in the left hand column and assigns the numerical ids\n",
-    " - **Transform** the data, which turns a sentence into it's bag of words representation"
+    " - **Transform** the data, which turns a sentence into its bag of words representation\n",
+    " \n",
+    "Note that the bag of words representation of a sentence ignores the word order and dependencies between them."
    ]
   },
   {
@@ -259,9 +247,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "sentence = [\"Literally just 8 really really cute dogs\"]\n",
@@ -279,9 +265,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "vectorizer.transform(sentence).toarray()"
@@ -297,9 +281,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "sentence = [\"OMG 5 truly hilarious dogs 😂\"]\n",
@@ -312,7 +294,7 @@
    "source": [
     "## Classifier\n",
     "\n",
-    "The standard classification problem is to find a boundary the best seperates classes. In the binary classification problem below, we've indicated a linear boundary that separates the data pretty well. Each sample is described by the number of times that word1 and word2 occur. In reality we will have many more words associated with each sample but the concept remains the same.\n",
+    "In the classification task, we take a single example (such as an article row) and decide which class it belongs to (e.g., clickbait or not clickbait). A standard approach to classification is to find a boundary that best seperates training examples according to their class. In the binary classification problem below, we've indicated a linear boundary that separates the data pretty well. Each sample is described by the number of times that word1 and word2 occur. In reality we will have many more words associated with each sample but the concept remains the same.\n",
     "\n",
     "We determine this boundary using a Support Vector Machine. The SVM has two steps:\n",
     " - **Fit** we learn the boundary from labelled data\n",
@@ -357,9 +339,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from utils.plotting import plot_2d_samples\n",
@@ -388,7 +368,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
     "scrolled": false
    },
    "outputs": [],
@@ -407,9 +386,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "svc.predict([[3, 1], [2,4]])"
@@ -431,7 +408,7 @@
     "\n",
     "We'll create a pipeline with two steps:\n",
     "1. Transform textual data to a bag of words vector\n",
-    "2. Predict label from bag of words vector\n",
+    "2. Predict label from the bag of words vector\n",
     "\n",
     "So the input of our pipeline is text data and the output is a label!"
    ]
@@ -498,7 +475,7 @@
     "from sklearn.model_selection import train_test_split\n",
     "training, testing = train_test_split(\n",
     "    df,                # The dataset we want to split\n",
-    "    train_size=0.7,    # The proportinal size of our training set\n",
+    "    train_size=0.7,    # The proportional size of our training set\n",
     "    stratify=df.label, # The labels are used for stratification\n",
     "    random_state=400   # Use the same random state for reproducibility\n",
     ")"
@@ -507,9 +484,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "training.head(5)"
@@ -518,9 +493,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print(len(training))\n",
@@ -559,9 +532,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "pipeline.predict([\"Literally just 8 incredible dog videos.\"])"
@@ -570,9 +541,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "pipeline.predict([\"French election polls show an early lead for Macron.\"])"
@@ -607,7 +576,7 @@
    "metadata": {},
    "source": [
     "Some parameters we can fiddle:\n",
-    " - stop_words - we can ignore certain words (the, a, it,...). scikit-learn has an 'english' stop word vocab we can try\n",
+    " - stop_words - we can ignore certain words (the, a, it,...). scikit-learn has an 'english' stop word vocabulary we can use\n",
     " - ngram_range - in the above example we split sentences into words. We could also try pairs of words.\n",
     " - C - the SVM has a property C that performs regularisation\n",
     " \n",
@@ -632,9 +601,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from sklearn.model_selection import GridSearchCV\n",
@@ -645,9 +612,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print(gs.best_params_)"
@@ -687,9 +652,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from sklearn.metrics import accuracy_score\n",
@@ -701,9 +664,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from sklearn.metrics import confusion_matrix\n",
@@ -721,7 +682,7 @@
     "\n",
     "![hunger](https://ronanwills.files.wordpress.com/2015/06/vlcsnap-2015-06-11-23h05m49s76.png?w=625)\n",
     "\n",
-    "One excellent feature of scikit learn is that we can save our classifier using the pickle tool. We can load it later for\n",
+    "An excellent feature of scikit-learn is that we can save our classifier using the pickle tool. We can load it later for\n",
     " - data analysis\n",
     " - data provenance\n",
     " - to share with somebody\n",


### PR DESCRIPTION
Liking things, Andraz will have a PR with some additions/changes to the code. I reviewed the descriptions. 

I like the look of the pipeline diagram a lot, but there is some ambiguity there that could confuse readers. If you have access to the original files, I'd suggest the following changes:
- the arrows from both 'parameters' boxes should go to 'Transform' instead of 'Output'
- I'd rename 'Classifying features' into 'Test features' so that they correspond to 'Training features'
- the fact that both train and test goes through the same pipeline and are joined into one arrow at the transformer output means that it is not clear that the classifer is fitted only on the transformed training data and not on the transformed test data. In order to make that clear, I think you'd effectively need two pipelines, one for training (both fit+transform) and one for testing (just transform), where the latter uses the parameters of the training one.

What do you think?