### PR TITLE
Fix for scikit-learn 0.19 regression bug

### DIFF
--- a/tutorial.ipynb
+++ b/tutorial.ipynb
@@ -417,10 +417,10 @@
    },
    "outputs": [],
    "source": [
-    "steps = (\n",
+    "steps = [\n",
     "    ('vectorizer', CountVectorizer()),\n",
     "    ('classifier', LinearSVC())\n",
-    ")"
+    "]"
    ]
   },
   {
@@ -463,9 +463,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from sklearn.model_selection import train_test_split\n",
@@ -658,10 +656,10 @@
    "source": [
     "from sklearn.feature_extraction.text import TfidfVectorizer\n",
     "\n",
-    "steps = (\n",
+    "steps = [\n",
     "    ('vectorizer', TfidfVectorizer()),\n",
     "    ('classifier', LinearSVC())\n",
-    ")\n",
+    "]\n",
     "pipeline = Pipeline(steps)\n",
     "\n",
     "predicted_labels = cross_val_predict(pipeline, training.full_content, training.label)\n",
@@ -689,10 +687,10 @@
     "def mask_integers(s):\n",
     "    return re.sub(r'\\d+', 'INTMASK', s)\n",
     "\n",
-    "steps = (\n",
+    "steps = [\n",
     "    ('vectorizer', TfidfVectorizer(preprocessor=mask_integers)),\n",
     "    ('classifier', LinearSVC())\n",
-    ")\n",
+    "]\n",
     "pipeline = Pipeline(steps)\n",
     "\n",
     "predicted_labels = cross_val_predict(pipeline, training.full_content, training.label)\n",
@@ -716,10 +714,10 @@
    },
    "outputs": [],
    "source": [
-    "steps = (\n",
+    "steps = [\n",
     "    ('vectorizer', TfidfVectorizer()),\n",
     "    ('classifier', LinearSVC())\n",
-    ")\n",
+    "]\n",
     "\n",
     "pipeline = Pipeline(steps)"
    ]
@@ -869,7 +867,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.1"
+   "version": "3.6.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Tutorial notebook would not run with scikit-learn 0.19, since it enforces Pipeline steps to be mutable (https://github.com/scikit-learn/scikit-learn/issues/9587).

This pull request changes the Pipeline steps objects from tuples to lists, to workaround the issue.